### PR TITLE
Fix NullPointerException when using SYSTEM_DEFAULT vulkan driver

### DIFF
--- a/app/src/main/java/com/zomdroid/GameLauncher.java
+++ b/app/src/main/java/com/zomdroid/GameLauncher.java
@@ -43,7 +43,10 @@ public class GameLauncher {
         switch (LauncherPreferences.requireSingleton().getRenderer()) {
             case ZINK_ZFA:
             case ZINK_OSMESA:
-                Os.setenv("ZOMDROID_VULKAN_DRIVER_NAME", LauncherPreferences.requireSingleton().getVulkanDriver().libName, false);
+                String vulkanDriverName = LauncherPreferences.requireSingleton().getVulkanDriver().libName;
+                if (vulkanDriverName != null) {
+                    Os.setenv("ZOMDROID_VULKAN_DRIVER_NAME", vulkanDriverName, false);
+                }
                 break;
         }
 


### PR DESCRIPTION
Hi again,
now I fixed my branch an push it again....

I'd like to propose a small change to restore the functionality from v1.0.0 regarding the SYSTEM_DEFAULT Vulkan driver. This feature is particularly useful for certain modded/rooted devices.

Personally, I'm using a OnePlus 8T with Mesa Turnip as the system driver, and enabling SYSTEM_DEFAULT gives me the best compatibility and performance. I believe this change could benefit other users with similar setups.

# Description
Fixes a NullPointerException that occurs when using SYSTEM_DEFAULT vulkan driver.

## Changes
- Added null check in GameLauncher.java to prevent crashes
- Ensures vulkan driver name is properly validated before use

## Testing
- Tested with SYSTEM_DEFAULT vulkan driver configuration
- No more crashes observed